### PR TITLE
Return unformatted percent value from apy contract call

### DIFF
--- a/src/proxy/ElfProxy.sol
+++ b/src/proxy/ElfProxy.sol
@@ -32,7 +32,7 @@ contract ElfProxy {
 
     function getPoolAPY(address payable _pool) external pure returns (uint256) {
         require(_pool != address(0));
-        return 2.13 * 10**18;
+        return 2.13 * 10**16;
     }
 
     function getNumPoolAllocations(address payable _pool)


### PR DESCRIPTION
We should leave formatting up to the frontend, eg: `apy` value should come down as `0.0214` that the FE then formats as `2.14%`.