### PR TITLE
Output contract addresses to json file

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,6 +19,9 @@ echo "PROXY=$PROXY_ADDRESS"
 ELF_ADDRESS=$(seth call $ELF_DEPLOY_ADDRESS "elf()(address)")
 echo "ELF=$ELF_ADDRESS"
 
+CONTRACT_ADDRESSES='{"ELF_DEPLOY":"%s","ELF_PROXY":"%s","ELF":"%s"}\n'
+printf "$CONTRACT_ADDRESSES" "$ELF_DEPLOY_ADDRESS" "$PROXY_ADDRESS" "$ELF_ADDRESS" > ./out/contracts.json
+
 echo ""
 
 echo "Configuring contracts..."


### PR DESCRIPTION
FE needs a better way to get the localnet contract addresses from `elf-deploy`, currently we're hardcoding them: https://github.com/element-fi/efi-frontend/blob/master/frontend/src/efi/contracts/Elf.ts#L15

This PR adds an `out/contracts.json` file during deploy.  Then when setting up an FE dev environment we can then symlink to this file.