### PR TITLE
Fix YieldPool call to registerTokens

### DIFF
--- a/contracts/YieldPool.sol
+++ b/contracts/YieldPool.sol
@@ -70,7 +70,7 @@ contract YieldCurvePool is IMinimalSwapInfoPool, BalancerPoolToken {
         IERC20[] memory tokens = new IERC20[](2);
         tokens[0] = _underlying;
         tokens[1] = _bond;
-        vault.registerTokens(poolId, tokens, new address[](0));
+        vault.registerTokens(poolId, tokens, new address[](2));
 
         // Set immutable state variables
         _vault = vault;


### PR DESCRIPTION
PoolRegistry's registerTokens function requires tokens.length to equal assetManagers.length.  We were setting the assetManagers length to zero.  Hardcoding this to 2 since we'll only ever have 2 tokens in this particular pool.